### PR TITLE
Fix strapi-cache: rethrow if not plugin error

### DIFF
--- a/server/src/middlewares/cache.ts
+++ b/server/src/middlewares/cache.ts
@@ -47,8 +47,11 @@ const middleware = async (ctx: Context, next: any) => {
     }
     loggy.info(`INIT with key: ${key}`);
     await cacheStore.set(key, { init: true });
+
+    let cacheError = false;
     try {
       await next();
+      cacheError = true;
       if (statusIsCachable(ctx)) {
         loggy.info(`MISS with key: ${key}`);
         const headersToStore = cacheHeaders ? ctx.response.headers : null;
@@ -73,12 +76,16 @@ const middleware = async (ctx: Context, next: any) => {
         throw new Error('NOT_CACHABLE');
       }
     } catch (e) {
+      cacheStore.del(key);
       if (e.message === 'NOT_CACHABLE') {
         loggy.info(`${e.message} with key: ${key}`);
       } else {
-        loggy.error(`${e.stack} with key: ${key}`);
+        if (cacheError) {
+          loggy.error(`${e.stack} with key: ${key}`);
+        } else {
+          throw e;
+        }
       }
-      cacheStore.del(key);
     }
     return;
   }


### PR DESCRIPTION
If error is from plugin:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/b9210001-308b-4bdf-b2c4-d496a41c0568" />

If error is from next() (other sources):
<img width="629" alt="image" src="https://github.com/user-attachments/assets/0797f11b-3f05-45fa-8207-cd8ccd85ce11" />
